### PR TITLE
add initial deploy-script & GHA

### DIFF
--- a/.github/workflows/shinyapps-io.yaml
+++ b/.github/workflows/shinyapps-io.yaml
@@ -29,5 +29,11 @@ jobs:
       - name: Install R dependecies
         run: |
           source("deploy-shinyapps-io.R")
+          install_deps()
+        shell: Rscript {0}
+
+      - name: Deploy the app for this branch
+        run: |
+          source("deploy-shinyapps-io.R")
           deploy(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io.yaml
+++ b/.github/workflows/shinyapps-io.yaml
@@ -16,6 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
+      SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
     steps:
@@ -28,4 +29,5 @@ jobs:
       - name: Install R dependecies
         run: |
           source("deploy-shinyapps-io.R")
+          deploy(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io.yaml
+++ b/.github/workflows/shinyapps-io.yaml
@@ -1,0 +1,31 @@
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - master
+
+name: shinyapps-deploy
+
+jobs:
+  shinyapps-deploy:
+    runs-on: ubuntu-18.04
+
+    env:
+      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
+      SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
+      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+        id: install-r
+
+      - name: Install R dependecies
+        run: |
+          source("deploy-shinyapps-io.R")
+        shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # Old-faithful
 
-This is a sandpit app, with which I'm learning how to add CI/CD using GHA and shinyapps.io
+This is a sandpit app, to demonstrate how to add CI/CD using GHA and shinyapps.io
+
+# Deployment to shinyapps-io on push
+
+Workflow `./.github/workflows/shinyapps-io.yaml` is used to deploy to shinyapps.io
+
+## Github secrets
+
+To use the deploy workflow, you must define some values as github-secrets in your repository.
+Github secrets are a way to store values that shouldn't be shared in your repository (eg, api keys
+for hosting sites, database access keys).
+
+The required values are:
+
+- Secrets regarding your shinyapps.io account:
+  - `SHINYAPPS_IO_ACCOUNT`
+  - `SHINYAPPS_IO_TOKEN`
+  - `SHINYAPPS_IO_SECRET`
+
+To get theshinyapps.io values, go to [https://www.shinyapps.io/admin/#/tokens]() and click "show"
+on your shinyapps.io token.
+A modal will show up that looks like:
+
+```
+    rsconnect::setAccountInfo(name='<MY-ACCOUNT-NAME>',
+                              token='<MY-TOKEN>',
+                              secret='<SECRET>')
+```
+
+Make sure you do not share the "<SECRET>" value with anyone.
+
+To add values as github secrets to a repository on github:
+
+- GOTO: [repo] -> settings -> secrets
+- Click "New repository secret"
+- Add the name of the relevant secret (eg, `SHINYAPPS_IO_ACCOUNT`, `SHINYAPPS_IO_TOKEN`, ...) into
+  the "Name" field
+- Add the value of the relevant secret to the "Value field"
+
+You will be taken back to the "secrets" section of the github repository where the names of all
+your currently-defined github-secrets are shown.
+
+## Github action
+
+Branches get deployed to: `<URL_PREFIX>-<branch-name>`
+Merges into main get deployed to: `<URL_PREFIX>`
+
+.. where `URL_PREFIX` is the main site.

--- a/deploy-shinyapps-io.R
+++ b/deploy-shinyapps-io.R
@@ -1,0 +1,64 @@
+## Needs suggests for rsconnect to deploy
+install.packages("rsconnect", dependencies = TRUE)
+if (!requireNamespace("stringr", quietly = TRUE)) install.packages("stringr")
+if (!requireNamespace("cli", quietly = TRUE)) install.packages("cli")
+if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+
+# Needs the following secrets:
+# github.com/username/repo -> Settings -> Secrets
+# SHINYAPPS_IO_TOKEN
+# SHINYAPPS_IO_SECRET
+
+
+# message(Sys.getenv('GITHUB_REPOSITORY'))
+# message(Sys.getenv("GITHUB_REF"))
+# message(Sys.getenv("COMMIT_MESSAGE"))
+
+# This function would be used if the Shiny app was a package
+# Self install from the branch, then deploy
+# install_pkg = function() {
+#   cli::cli_h1("Install pkg")
+#   path = paste(Sys.getenv('GITHUB_REPOSITORY'), Sys.getenv("GITHUB_REF"), sep = "@")
+#   cli::cli_alert_info("Installing {path}")
+#   remotes::install_github(path, upgrade = "never")
+#   cli::cli_alert_success("{path} installed!")
+# }
+#
+
+deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
+  cli::cli_h1("Deploying app")
+  rsconnect::setAccountInfo(name = account,
+                            token = Sys.getenv("SHINYAPPS_IO_TOKEN"),
+                            secret = Sys.getenv("SHINYAPPS_IO_SECRET"))
+
+  branch_name = stringr::str_match(Sys.getenv('GITHUB_REF'), "^refs/heads/(.*)$")[1, 2]
+  repo_name = stringr::str_match(Sys.getenv("GITHUB_REPOSITORY"), ".*/(.*)$")[1, 2]
+  appName = if (branch_name %in% c("master", "main")) repo_name
+  else paste(repo_name, branch_name, sep = "-")
+
+  cli::cli_alert_info("appName: ", appName)
+  rsconnect::deployApp(
+    account = account, server = server,
+    appDir = ".",
+    appName = appName)
+  cli::cli_alert_success("{appName} successfully deployed")
+}
+
+# Clean up after merging.
+# terminate = function(account = "jumpingrivers", server = "shinyapps.io") {
+#   msg = Sys.getenv("TRAVIS_COMMIT_MESSAGE")
+#   if (stringr::str_detect(msg, "^Merge pull", negate = TRUE)) return(NULL)
+#
+#   cli::cli_h1("Terminating app")
+#   branch = stringr::str_match(msg, "/([^-\\s]*)")[1, 2]
+#   slug = stringr::str_match(Sys.getenv('TRAVIS_REPO_SLUG'), "/(.*)")[1, 2]
+#
+#   appName = paste(slug, branch, sep = '-')
+#   rsconnect::terminateApp(appName = appName, account = account, server = server)
+#   cli::cli_alert_success("{appName} successfully terminated")
+# }
+#
+
+# install_pkg()
+deploy(account = "jumpingrivers")
+#terminate(account = "nationalarchives")

--- a/deploy-shinyapps-io.R
+++ b/deploy-shinyapps-io.R
@@ -1,8 +1,10 @@
 ## Needs suggests for rsconnect to deploy
-install.packages("rsconnect", dependencies = TRUE)
-if (!requireNamespace("stringr", quietly = TRUE)) install.packages("stringr")
-if (!requireNamespace("cli", quietly = TRUE)) install.packages("cli")
-if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+install_deps = function() {
+  install.packages("rsconnect", dependencies = TRUE)
+  if (!requireNamespace("stringr", quietly = TRUE)) install.packages("stringr")
+  if (!requireNamespace("cli", quietly = TRUE)) install.packages("cli")
+  if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+}
 
 # Needs the following secrets:
 # github.com/username/repo -> Settings -> Secrets

--- a/deploy-shinyapps-io.R
+++ b/deploy-shinyapps-io.R
@@ -66,6 +66,5 @@ deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
 # }
 #
 
-# install_pkg()
-deploy(account = "jumpingrivers")
-# terminate(account = "nationalarchives")
+# user should call the appropriate functions in GHA recipe
+# eg, deploy(account = my_account)

--- a/deploy-shinyapps-io.R
+++ b/deploy-shinyapps-io.R
@@ -27,21 +27,28 @@ if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
 
 deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
   cli::cli_h1("Deploying app")
-  rsconnect::setAccountInfo(name = account,
-                            token = Sys.getenv("SHINYAPPS_IO_TOKEN"),
-                            secret = Sys.getenv("SHINYAPPS_IO_SECRET"))
+  rsconnect::setAccountInfo(
+    name = account,
+    token = Sys.getenv("SHINYAPPS_IO_TOKEN"),
+    secret = Sys.getenv("SHINYAPPS_IO_SECRET")
+  )
 
-  branch_name = stringr::str_match(Sys.getenv('GITHUB_REF'), "^refs/heads/(.*)$")[1, 2]
+  branch_name = stringr::str_match(Sys.getenv("GITHUB_REF"), "^refs/heads/(.*)$")[1, 2]
   repo_name = stringr::str_match(Sys.getenv("GITHUB_REPOSITORY"), ".*/(.*)$")[1, 2]
-  appName = if (branch_name %in% c("master", "main")) repo_name
-  else paste(repo_name, branch_name, sep = "-")
+  app_name = if (branch_name %in% c("master", "main")) {
+    repo_name
+  } else {
+    paste(repo_name, branch_name, sep = "-")
+  }
 
-  cli::cli_alert_info("appName: ", appName)
+  cli::cli_alert_info("appName: ", app_name)
   rsconnect::deployApp(
-    account = account, server = server,
+    account = account,
+    server = server,
     appDir = ".",
-    appName = appName)
-  cli::cli_alert_success("{appName} successfully deployed")
+    appName = app_name
+  )
+  cli::cli_alert_success("{app_name} successfully deployed")
 }
 
 # Clean up after merging.
@@ -61,4 +68,4 @@ deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
 
 # install_pkg()
 deploy(account = "jumpingrivers")
-#terminate(account = "nationalarchives")
+# terminate(account = "nationalarchives")


### PR DESCRIPTION
As written by csgillespie in
[https://github.com/csgillespie/GA-testing/blob/main/deploy-shinyapps-io.R]()

AIMS:
- [x] ensure deploy step fails without secrets
- [x] ensure script is generalised to handle non-"jumpingrivers" usernames
- [x] with correct secrets in place, ensure deployment happens
- [x] ensure deploy step fails with incorrect account-name
- [x] ensure deploy step fails incorrect named env var: SHIYNAPPS_IO_SECRET
- ~~ensure deployment only happens after linting passes (move to issue)~~
- [x] document (in the README)
  - [x] the URL for deployed branches
  - [x] the secrets that are required for basic deployment

MINOR:
- [x] fix linting step: it should fail with lints and pass without
- ~~move deploy script to ./deploy or ./.github/scripts~~ (ignore for now)