### PR TITLE
push an API_KEY secret into .Renviron prior to deploy

### DIFF
--- a/.github/workflows/shinyapps-io.yaml
+++ b/.github/workflows/shinyapps-io.yaml
@@ -32,6 +32,10 @@ jobs:
           install_deps()
         shell: Rscript {0}
 
+      - name: Put run-required secrets into .Renviron
+        run: |
+          echo "API_KEY=${{ secrets.NOT_MY_API_KEY }}" >> .Renviron
+
       - name: Deploy the app for this branch
         run: |
           source("deploy-shinyapps-io.R")

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The required values are:
   - `SHINYAPPS_IO_TOKEN`
   - `SHINYAPPS_IO_SECRET`
 
+- Secrets that are used during the running of the app (these are put into .Renviron prior to
+  deployment)
+  - `NOT_MY_API_KEY`
+
 To get theshinyapps.io values, go to [https://www.shinyapps.io/admin/#/tokens]() and click "show"
 on your shinyapps.io token.
 A modal will show up that looks like:

--- a/app.R
+++ b/app.R
@@ -8,6 +8,14 @@
 #
 
 library(shiny)
+library(magrittr)
+
+get_or_else = function(x, default) {
+  stopifnot(is.character(x))
+  if (x == "") default else x
+}
+
+api_key = Sys.getenv("API_KEY") %>% get_or_else("DEFAULT_VALUE")
 
 # Define UI for application that draws a histogram
 ui = fluidPage(
@@ -23,7 +31,8 @@ ui = fluidPage(
         min = 1,
         max = 50,
         value = 30
-      )
+      ),
+      textOutput("api_key")
     ),
 
     # Show a plot of the generated distribution
@@ -35,6 +44,8 @@ ui = fluidPage(
 
 # Define server logic required to draw a histogram
 server = function(input, output) {
+
+  output$api_key = renderText(paste0("API_KEY: ", api_key))
   output$dist_plot = renderPlot({
     # generate bins based on input$bins from ui.R
     x = faithful[, 2]


### PR DESCRIPTION
AIMS:
- [x] User can pass a secret from github to shinyapps.io for use while their app is running
- [x] Modify app to use env var "API_KEY" (printing it in the app)
- [x] API_KEY is added to .Renviron by a job in the deploy workflow
- [x] .Renviron / API_KEY is not visible in the repo
- [ ] ~~deploy workflow fails if NOT_MY_API_KEY is not a secret~~ (moved to issue)
- [x] API_KEY is visible in the branch-deployed app