### PR TITLE
app depends on a non-standard CRAN and GH pkg

### DIFF
--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -35,10 +35,16 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
         id: install-r
 
-      - name: Install R dependecies
+      - name: Install R deployment dependencies
         run: |
           source("${{ env.SCRIPT }}")
           install_deps()
+        shell: Rscript {0}
+
+      - name: Install R runtime dependencies
+        run: |
+          install.packages('remotes')
+          remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
 
       - name: Put run-required secrets into .Renviron

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -32,6 +32,10 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v2
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+
       - uses: r-lib/actions/setup-r@v1
         id: install-r
 

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev
           sudo apt-get install -y libgdal-dev
           sudo apt-get install -y libudunits2-dev

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libgdal-dev
+          sudo apt-get install -y libudunits2-dev
+          sudo apt-get install -y libmagick++-dev
 
       - uses: r-lib/actions/setup-r@v1
         id: install-r

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -41,12 +41,14 @@ jobs:
 
       - name: Install R deployment dependencies
         run: |
+          options(warn = 2)
           source("${{ env.SCRIPT }}")
           install_deps()
         shell: Rscript {0}
 
       - name: Install R runtime dependencies
         run: |
+          options(warn = 2)
           install.packages('remotes')
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
@@ -57,6 +59,7 @@ jobs:
 
       - name: Deploy the app for this branch
         run: |
+          options(warn = 2)
           source("${{ env.SCRIPT }}")
           deploy(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,19 @@
+Package: old-faithful-sandpit
+Title: What the Package Does (One Line, Title Case)
+Version: 0.0.0.9000
+Authors@R: 
+    person(given = "Russ",
+           family = "Hyde",
+           role = c("aut", "cre"),
+           email = "russ.hyde.data@gmail.com")
+Description: What the package does (one paragraph).
+License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
+    license
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.1
+Imports: 
+    ggplot2,
+    magrittr,
+    shiny

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,10 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Imports: 
+    ggpattern (>= 0.1.3),
     ggplot2,
     magrittr,
+    palmerpenguins,
     shiny
+Remotes:  
+    coolbutuseless/ggpattern

--- a/app.R
+++ b/app.R
@@ -9,13 +9,50 @@
 
 library(shiny)
 library(magrittr)
+library(ggplot2)
+library(ggpattern) # needs install from GH (remotes)
+library(palmerpenguins) # needs install from CRAN
 
-get_or_else = function(x, default) {
+or_else = function(x, default) {
   stopifnot(is.character(x))
   if (x == "") default else x
 }
 
-api_key = Sys.getenv("API_KEY") %>% get_or_else("DEFAULT_VALUE")
+api_key = Sys.getenv("API_KEY") %>% or_else("DEFAULT_VALUE")
+
+plot_patterns = function() {
+  if (!requireNamespace("ggpattern")) {
+    stop("require {ggpattern}")
+  }
+  df = data.frame(
+    level = factor(c("a", "b", "c", "d")),
+    outcome = c(2.3, 1.9, 3.2, 1)
+  )
+
+  ggplot2::ggplot(df) +
+    ggpattern::geom_col_pattern(
+      ggplot2::aes(level, outcome, pattern_fill = level),
+      pattern = "stripe",
+      fill    = "white",
+      colour  = "black"
+    ) +
+    ggplot2::theme_bw(18) +
+    ggplot2::theme(legend.position = "none") +
+    ggplot2::labs(
+      title = "ggpattern::geom_pattern_col()",
+      subtitle = "pattern = 'stripe'"
+    ) +
+    ggplot2::coord_fixed(ratio = 1 / 2)
+}
+
+plot_faithful = function(n_bins) {
+  # generate bins based on input$bins from ui.R
+  x = faithful[, 2]
+  bins = seq(min(x), max(x), length.out = n_bins + 1)
+
+  # draw the histogram with the specified number of bins
+  hist(x, breaks = bins, col = "darkgray", border = "white")
+}
 
 # Define UI for application that draws a histogram
 ui = fluidPage(
@@ -37,22 +74,45 @@ ui = fluidPage(
 
     # Show a plot of the generated distribution
     mainPanel(
-      plotOutput("dist_plot")
+      plotOutput("dist_plot"),
+      plotOutput("pattern_plot"),
+      plotOutput("penguin_plot")
     )
   )
 )
 
+plot_penguins = function() {
+  flipper_hist = ggplot2::ggplot(
+    data = penguins,
+    ggplot2::aes(x = flipper_length_mm)
+  ) +
+    ggplot2::geom_histogram(
+      ggplot2::aes(fill = species),
+      alpha = 0.5,
+      position = "identity"
+    ) +
+    ggplot2::scale_fill_manual(values = c("darkorange", "purple", "cyan4")) +
+    ggplot2::theme_minimal() +
+    ggplot2::labs(
+      x = "Flipper length (mm)",
+      y = "Frequency",
+      title = "Penguin flipper lengths"
+    )
+
+  flipper_hist
+}
+
 # Define server logic required to draw a histogram
 server = function(input, output) {
-
   output$api_key = renderText(paste0("API_KEY: ", api_key))
   output$dist_plot = renderPlot({
-    # generate bins based on input$bins from ui.R
-    x = faithful[, 2]
-    bins = seq(min(x), max(x), length.out = input$bins + 1)
-
-    # draw the histogram with the specified number of bins
-    hist(x, breaks = bins, col = "darkgray", border = "white")
+    plot_faithful(n_bins = input$bins)
+  })
+  output$pattern_plot = renderPlot({
+    plot_patterns()
+  })
+  output$penguin_plot = renderPlot({
+    plot_penguins()
   })
 }
 


### PR DESCRIPTION
AIM:
- ensure runtime dependencies (from CRAN) are passed to shinyapps.io by GHA
- ensure runtime dependencies (remotes) are passed to shinyapps.io by GHA

Added runtime dependnecy on
- {palmerpenguins} from CRAN
- {ggpattern} from github (since this is used in a client project)

These are unlikely to be available in the GHA server prior to pushing to shinyapps.io

Expect to define dependencies in a DESCRIPTION file

Tasks:
- [x] Add runtime dependencies into source code (ggpattern, palmerpenguins)
- [x] Add DESCRIPTION file
- [x] Add standard dependencies into DESCRIPTION (shiny, magrittr, ggplot2) & watch deploy fail
- [x] Add ggpattern and palmerpenguins to DESCRIPTION & watch deploy fail
- [x] Add GHA job to install runtime dependencies
- [x] Watch deploy pass