### PR TITLE
Install system-dependencies required for app termination

### DIFF
--- a/.github/scripts/deploy-shinyapps-io.R
+++ b/.github/scripts/deploy-shinyapps-io.R
@@ -1,5 +1,5 @@
 ## Needs suggests for rsconnect to deploy
-install_deps = function() {
+install_script_deps = function() {
   install.packages("rsconnect", dependencies = TRUE)
   if (!requireNamespace("stringr", quietly = TRUE)) install.packages("stringr")
   if (!requireNamespace("cli", quietly = TRUE)) install.packages("cli")

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           options(warn = 2)
           source("${{ env.SCRIPT }}")
-          install_deps()
+          install_script_deps()
         shell: Rscript {0}
 
       - name: Install R runtime dependencies

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -17,10 +17,10 @@ name: shinyapps-deploy
 
 jobs:
   shinyapps-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -21,17 +21,24 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v2
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+
       - uses: r-lib/actions/setup-r@v1
         id: install-r
 
-      - name: Install R dependecies
+      - name: Install app-termination R dependencies
         run: |
+          options(warn = 2)
           source("${{ env.SCRIPT }}")
           install_deps()
         shell: Rscript {0}
 
       - name: Teardown the app for this closed branch
         run: |
+          options(warn = 2)
           source("${{ env.SCRIPT }}")
           terminate(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           options(warn = 2)
           source("${{ env.SCRIPT }}")
-          install_deps()
+          install_script_deps()
         shell: Rscript {0}
 
       - name: Teardown the app for this closed branch

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -6,10 +6,10 @@ name: shinyapps-teardown
 
 jobs:
   shinyapps-terminate:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}


### PR DESCRIPTION
fix #18
fix #19

In #15 , code was added to ensure that system-dependencies (libcurl, gdal etc) were installed before attempting to install deployment- or runtime-dependency R packages.
Here we ensure system-deps are in place before installing packages required to terminate() an app on shinyapps.io.

Also:

- refactoring: renamed a function in the script that installs dependencies for the deploy() and terminate() functions (because it's earlier name clashed with remotes::install_deps() ; See Colin's comment in #15 )
- refactoring: several jobs in the deploy and terminate workflows set `options(warn = 2)` when running Rscript; this was unnecessary duplication, and setting this option is now pushed into .Rprofile by another job in the workflow