### PR TITLE
set Rscript options for GHA workflow in .Rprofile

### DIFF
--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -43,16 +43,18 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
         id: install-r
 
-      - name: Install R deployment dependencies
+      - name: Set Rscript to fail on warnings
         run: |
-          options(warn = 2)
+          echo "options(warn = 2)" >> .Rprofile
+
+      - name: Install app-deployment R dependencies
+        run: |
           source("${{ env.SCRIPT }}")
           install_deps()
         shell: Rscript {0}
 
-      - name: Install R runtime dependencies
+      - name: Install app-runtime R dependencies
         run: |
-          options(warn = 2)
           install.packages('remotes')
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
@@ -63,7 +65,6 @@ jobs:
 
       - name: Deploy the app for this branch
         run: |
-          options(warn = 2)
           source("${{ env.SCRIPT }}")
           deploy(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
         shell: Rscript {0}


### PR DESCRIPTION
Deduplicates the use of `Rscript -e "options(...)"` across jobs