### PR TITLE
User specified appname

### DIFF
--- a/.github/scripts/deploy-shinyapps-io.R
+++ b/.github/scripts/deploy-shinyapps-io.R
@@ -55,11 +55,11 @@ get_repo_name = function() {
 
 get_app_name = function() {
   branch_name = get_branch_name()
-  repo_name = get_repo_name()
+  app_basename = get_repo_name()
   app_name = if (branch_name %in% c("master", "main")) {
-    repo_name
+    app_basename
   } else {
-    paste(repo_name, branch_name, sep = "-")
+    paste(app_basename, branch_name, sep = "-")
   }
   app_name
 }

--- a/.github/scripts/deploy-shinyapps-io.R
+++ b/.github/scripts/deploy-shinyapps-io.R
@@ -55,7 +55,7 @@ get_repo_name = function() {
 
 get_app_name = function() {
   branch_name = get_branch_name()
-  app_basename = get_repo_name()
+  app_basename = Sys.getenv("APP_BASENAME", get_repo_name())
   app_name = if (branch_name %in% c("master", "main")) {
     app_basename
   } else {

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      APP_BASENAME: my-app
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      APP_BASENAME: my-app
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}


### PR DESCRIPTION
App-name can be specified in the GHA workflow by setting the ENV variable "APP_BASENAME"

- [x] Uses repo-name if "APP_BASENAME" is not defined
- [x] Deploys to "APP_BASENAME" on merging-into / commiting-to main
- [x] Deploys to "APP_BASENAME-BRANCHNAME" on starting / modifying a PR