### PR TITLE
staging deploys can happen without the -<branch> suffix on the URL

### DIFF
--- a/.github/scripts/deploy-shinyapps-io.R
+++ b/.github/scripts/deploy-shinyapps-io.R
@@ -53,13 +53,17 @@ get_repo_name = function() {
   repo_name
 }
 
-get_app_name = function() {
-  branch_name = get_branch_name()
+get_app_name = function(include_branch) {
   app_basename = Sys.getenv("APP_BASENAME", get_repo_name())
+  app_suffix = if (include_branch) {
+    paste0("-", get_branch_name())
+  } else {
+    ""
+  }
   app_name = if (branch_name %in% c("master", "main")) {
     app_basename
   } else {
-    paste(app_basename, branch_name, sep = "-")
+    paste0(app_basename, app_suffix)
   }
   app_name
 }
@@ -68,10 +72,14 @@ get_app_name = function() {
 
 # Functions for calling by the user
 
-deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
+deploy = function(
+    account = "jumpingrivers",
+    server = "shinyapps.io",
+    include_branch = TRUE
+) {
   cli::cli_h1("Deploying app")
 
-  app_name = get_app_name()
+  app_name = get_app_name(include_branch = include_branch)
 
   cli::cli_alert_info("appName: ", app_name)
 
@@ -86,10 +94,14 @@ deploy = function(account = "jumpingrivers", server = "shinyapps.io") {
 }
 
 # Clean up (eg, after merging / closing a branch).
-terminate = function(account = "jumpingrivers", server = "shinyapps.io") {
+terminate = function(
+    account = "jumpingrivers",
+    server = "shinyapps.io",
+    include_branch = TRUE
+) {
   cli::cli_h1("Terminating app")
 
-  app_name = get_app_name()
+  app_name = get_app_name(include_branch = include_branch)
 
   rsconnect::terminateApp(
     account = account,
@@ -99,8 +111,13 @@ terminate = function(account = "jumpingrivers", server = "shinyapps.io") {
   cli::cli_alert_success("{app_name} successfully terminated")
 }
 
-configure = function(account = "jumpingrivers", server = "shinyapps.io", size = "large") {
-  app_name = get_app_name()
+configure = function(
+    account = "jumpingrivers",
+    server = "shinyapps.io",
+    size = "large",
+    include_branch = TRUE
+) {
+  app_name = get_app_name(include_branch = include_branch)
 
   rsconnect::configureApp(
     account = account,

--- a/.github/scripts/deploy-shinyapps-io.R
+++ b/.github/scripts/deploy-shinyapps-io.R
@@ -55,14 +55,14 @@ get_repo_name = function() {
 
 get_app_name = function(include_branch) {
   app_basename = Sys.getenv("APP_BASENAME", get_repo_name())
-  app_suffix = if (include_branch) {
-    paste0("-", get_branch_name())
-  } else {
-    ""
+  if (!include_branch) {
+    return(app_basename)
   }
+
   app_name = if (branch_name %in% c("master", "main")) {
     app_basename
   } else {
+    app_suffix = paste0("-", get_branch_name())
     paste0(app_basename, app_suffix)
   }
   app_name

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -23,6 +23,7 @@ jobs:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       APP_BASENAME: my-app
+      APP_INCLUDE_BRANCHNAME: FALSE
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}
@@ -81,7 +82,10 @@ jobs:
         run: |
           options(warn = 2)
           source("${{ env.SCRIPT }}")
-          deploy(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
+          deploy(
+            account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
+            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
+          )
         shell: Rscript {0}
 
       - name: Configure the runtime instance
@@ -90,6 +94,7 @@ jobs:
           source("${{ env.SCRIPT }}")
           configure(
             account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
+            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
             size = "${{ env.SHINYAPPS_IO_INSTANCE_SIZE }}"
           )
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -94,7 +94,7 @@ jobs:
           source("${{ env.SCRIPT }}")
           configure(
             account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
-            include_branch = ${{ env.APP_INCLUDE_BRANCH_SUFFIX }}
+            include_branch = ${{ env.APP_INCLUDE_BRANCH_SUFFIX }},
             size = "${{ env.SHINYAPPS_IO_INSTANCE_SIZE }}"
           )
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -22,8 +22,8 @@ jobs:
     env:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      APP_BASENAME: my-app
-      APP_INCLUDE_BRANCHNAME: FALSE
+      APP_BASENAME: "my-app"
+      APP_INCLUDE_BRANCH_SUFFIX: "FALSE"
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}
@@ -84,7 +84,7 @@ jobs:
           source("${{ env.SCRIPT }}")
           deploy(
             account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
-            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
+            include_branch = ${{ env.APP_INCLUDE_BRANCH_SUFFIX }}
           )
         shell: Rscript {0}
 
@@ -94,7 +94,7 @@ jobs:
           source("${{ env.SCRIPT }}")
           configure(
             account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
-            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
+            include_branch = ${{ env.APP_INCLUDE_BRANCH_SUFFIX }}
             size = "${{ env.SHINYAPPS_IO_INSTANCE_SIZE }}"
           )
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -12,6 +12,7 @@ jobs:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       APP_BASENAME: my-app
+      APP_INCLUDE_BRANCHNAME: FALSE
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}
@@ -55,5 +56,8 @@ jobs:
         run: |
           options(warn = 2)
           source("${{ env.SCRIPT }}")
-          terminate(account = "${{ env.SHINYAPPS_IO_ACCOUNT }}")
+          terminate(
+            account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
+            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
+          )
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -11,8 +11,8 @@ jobs:
     env:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      APP_BASENAME: my-app
-      APP_INCLUDE_BRANCHNAME: FALSE
+      APP_BASENAME: "my-app"
+      APP_INCLUDE_BRANCH_SUFFIX: "FALSE"
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}
@@ -58,6 +58,6 @@ jobs:
           source("${{ env.SCRIPT }}")
           terminate(
             account = "${{ env.SHINYAPPS_IO_ACCOUNT }}",
-            include_branch = ${{ env.APP_INCLUDE_BRANCHNAME }}
+            include_branch = ${{ env.APP_INCLUDE_BRANCH_SUFFIX }}
           )
         shell: Rscript {0}


### PR DESCRIPTION
eg, if main app is deployed to `<URL>`
then the option "APP_INCLUDE_BRANCHNAME=FALSE" allows PR-associated staging sites to be deployed directly to `<URL>`