### PR TITLE
fix bug: branch-name should be included in staging app

### DIFF
--- a/.github/workflows/shinyapps-io-deploy.yaml
+++ b/.github/workflows/shinyapps-io-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       APP_BASENAME: "my-app"
-      APP_INCLUDE_BRANCH_SUFFIX: "FALSE"
+      APP_INCLUDE_BRANCH_SUFFIX: "TRUE"
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}

--- a/.github/workflows/shinyapps-io-terminate.yaml
+++ b/.github/workflows/shinyapps-io-terminate.yaml
@@ -12,7 +12,7 @@ jobs:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       APP_BASENAME: "my-app"
-      APP_INCLUDE_BRANCH_SUFFIX: "FALSE"
+      APP_INCLUDE_BRANCH_SUFFIX: "TRUE"
       SHINYAPPS_IO_TOKEN: ${{ secrets.SHINYAPPS_IO_TOKEN }}
       SHINYAPPS_IO_SECRET: ${{ secrets.SHINYAPPS_IO_SECRET }}
       SHINYAPPS_IO_ACCOUNT: ${{ secrets.SHINYAPPS_IO_ACCOUNT }}


### PR DESCRIPTION
hot fix for mistake after not cleaning up #26 . 
Branch name should be included by default in the staging app URL, so that stagin apps are isolated from main app.
